### PR TITLE
Hide UI elements for survey appropriately (Edit, Delete, and Radio Buttons) 

### DIFF
--- a/assets/scripts/surveys/ui.js
+++ b/assets/scripts/surveys/ui.js
@@ -123,7 +123,18 @@ const onSubmitAnswerSuccess = function (response) {
 }
 
 const onSubmitAnswerFailure = function (response) {
-  console.log('lol nope')
+  try {
+    const responseObject = JSON.parse(response.responseText)
+    let reason
+    if (responseObject.errors) {
+      reason = responseObject.errors
+    } else {
+      reason = 'an unknown error occurred'
+    }
+    alert('Your response could not be submitted: ' + reason)
+  } catch (e) {
+    alert(response.responseText)
+  }
 }
 
 const onDeleteSurveyFailure = function (response) {

--- a/assets/scripts/surveys/ui.js
+++ b/assets/scripts/surveys/ui.js
@@ -71,6 +71,9 @@ const onTakeSurveysSuccess = function (response) {
     // so that we can hide them
     return surveyOwner !== store.user._id
   }).hide()
+  $('input[type=radio]').filter((index, radio) => {
+    return !radio.value
+  }).parents('.form-check').hide()
   // $('input[type="radio"]').each(() => {
   //   if ($(this).val() === '') {
   //     console.log($(this).parent())

--- a/assets/scripts/surveys/ui.js
+++ b/assets/scripts/surveys/ui.js
@@ -63,6 +63,14 @@ const onTakeSurveysSuccess = function (response) {
   // }, 3000)
   const takeSurveysHtml = takeSurveysTemplate({ surveys: response.surveys })
   $('#show-surveys-area').html(takeSurveysHtml)
+  // Hide the edit and delete buttons for surveys not owned by the current user
+  $('.edit-survey-button, .delete-survey-button').filter((index, button) => {
+    // note: not using index, but need it since button is passed as second parameter
+    const surveyOwner = button.getAttribute('data-owner')
+    // keep only ones where the survey owner is not the current user,
+    // so that we can hide them
+    return surveyOwner !== store.user._id
+  }).hide()
   // $('input[type="radio"]').each(() => {
   //   if ($(this).val() === '') {
   //     console.log($(this).parent())

--- a/assets/scripts/templates/survey.handlebars
+++ b/assets/scripts/templates/survey.handlebars
@@ -12,10 +12,10 @@
       <button class="view-survey-results-button btn btn-info" type="button" data-target="#modal-{{survey._id}}">
         View Results
       </button>
-      <button type="button" class="btn btn-info" data-toggle="modal" data-target="#modal-{{survey._id}}">
+      <button type="button" class="btn btn-info edit-survey-button" data-toggle="modal" data-target="#modal-{{survey._id}}" data-owner="{{survey.owner}}">
         Edit
       </button>
-      <button class="delete-survey-button btn btn-info submit remove" type="button">Delete</button></p>
+      <button class="delete-survey-button btn btn-info submit remove" type="button" data-owner="{{survey.owner}}">Delete</button></p>
 
     <!-- Update Quote Modal -->
     <div data-backdrop="true" class="modal fade update-modal" id="modal-{{survey._id}}" tabindex="-1" role="dialog" aria-labelledby="updateQuoteModalCenterTitle" aria-hidden="true">

--- a/assets/scripts/templates/take-surveys.handlebars
+++ b/assets/scripts/templates/take-surveys.handlebars
@@ -40,10 +40,10 @@
         <button class="view-survey-results-button btn btn-info" type="button" data-target="#modal-{{survey._id}}">
           View Results
         </button>
-        <button type="button" class="btn btn-info" data-toggle="modal" data-target="#modal-{{survey._id}}">
+        <button type="button" class="btn btn-info edit-survey-button" data-toggle="modal" data-target="#modal-{{survey._id}}" data-owner="{{survey.owner}}">
           Edit
         </button>
-        <button class="delete-survey-button btn btn-info submit remove" type="button">Delete</button></p>
+        <button class="delete-survey-button btn btn-info submit remove" type="button" data-owner="{{survey.owner}}">Delete</button></p>
     </form>
 
     <!-- Update Quote Modal -->


### PR DESCRIPTION
Hi team,

I added a data owner attribute to handlebars to compare it to the current user, which is the store.user. That way, I can tell if the current user is the same as the survey owner. In the case that they are not the same, I hid the "edit" and "delete" buttons. Now, users can only see edit and delete buttons if they created that survey.

I hid the empty radio buttons when users take surveys by using .filter... I hid the parents of the radio buttons, because if you don't, the height is still full with blank space, because the divs are still there but empty.

The try block is for error handling. It tries to parse the JSON to get the error reason. If the JSON parse doesn't have an errors property, it will say an unknown error occurred. If the JSON parse fails, it assumes the response itself is the error message and just shows that. 
* Let's put this error in the sidebar tomorrow - for now I have it in the alert just to get it to print out the appropriate data. *

Please review, and let me know if you have questions.

Natalyn